### PR TITLE
fix delimiter bug when starting servers

### DIFF
--- a/qldsmanager/util/supervisor.py
+++ b/qldsmanager/util/supervisor.py
@@ -52,7 +52,7 @@ class Supervisor:
     def build_command_line(self, sid, server, executable):
         command_line = [
             executable,
-            '+set fs_homepath %s/%s' % (os.path.expanduser('~/.quakelive/'), sid)
+            '+set fs_homepath %s/%s' % (os.path.expanduser('~/.quakelive'), sid)
         ]
 
         for k,v in sorted(server.items()):


### PR DESCRIPTION
Hi, 

I got this issue that supervisor is setting fs_homepath wrong.
Could this be resolved by removing slash?

-- Fredrik